### PR TITLE
Fix crash when getting current location

### DIFF
--- a/syrf-location/src/main/java/com/syrf/location/services/SYRFLocationTrackingService.kt
+++ b/syrf-location/src/main/java/com/syrf/location/services/SYRFLocationTrackingService.kt
@@ -124,7 +124,9 @@ open class SYRFLocationTrackingService : Service() {
                     null,
                     ContextCompat.getMainExecutor(this)
                 ) { location ->
-                    callback.invoke(SYRFLocationData(location), null)
+                    if (location != null) {
+                        callback.invoke(SYRFLocationData(location), null)
+                    }
                 }
             } else {
                 @Suppress("DEPRECATION")


### PR DESCRIPTION
Crash when getting current location returned null. Crash log as below.
```
04-26 18:59:08.029  4758  4758 E AndroidRuntime: FATAL EXCEPTION: main
04-26 18:59:08.029  4758  4758 E AndroidRuntime: Process: com.example.reactnativesyrfclient, PID: 4758
04-26 18:59:08.029  4758  4758 E AndroidRuntime: java.lang.NullPointerException: location must not be null
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at com.syrf.location.services.SYRFLocationTrackingService.getCurrentPosition$lambda-3(SYRFLocationTrackingService.kt:127)
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at com.syrf.location.services.SYRFLocationTrackingService.lambda$a66dTScJXRCDeYUq0fcOcmqGmHk(Unknown Source:0)
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at com.syrf.location.services.-$$Lambda$SYRFLocationTrackingService$a66dTScJXRCDeYUq0fcOcmqGmHk.accept(Unknown Source:4)
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at android.location.LocationManager$GetCurrentLocationTransport$1.operate(LocationManager.java:3138)
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at android.location.LocationManager$GetCurrentLocationTransport$1.operate(LocationManager.java:3135)
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at com.android.internal.listeners.ListenerExecutor.lambda$executeSafely$0(ListenerExecutor.java:127)
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at com.android.internal.listeners.ListenerExecutor$$ExternalSyntheticLambda0.run(Unknown Source:8)
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:938)
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:99)
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:201)
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:288)
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:7842)
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
04-26 18:59:08.029  4758  4758 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```
